### PR TITLE
Add api credentials to fujitsu_const

### DIFF
--- a/src/ayla_iot_unofficial/fujitsu_consts.py
+++ b/src/ayla_iot_unofficial/fujitsu_consts.py
@@ -1,7 +1,7 @@
 from enum import IntEnum, unique
 
-AYLA_APP_ID = "CJIOSP-id"
-AYLA_APP_SECRET = "CJIOSP-Vb8MQL_lFiYQ7DKjN0eCFXznKZE"
+FGLAIR_APP_ID = "CJIOSP-id"
+FGLAIR_APP_SECRET = "CJIOSP-Vb8MQL_lFiYQ7DKjN0eCFXznKZE"
 
 OEM_MODEL = "oem_model"
 PROP = "prop"

--- a/src/ayla_iot_unofficial/fujitsu_consts.py
+++ b/src/ayla_iot_unofficial/fujitsu_consts.py
@@ -1,5 +1,8 @@
 from enum import IntEnum, unique
 
+AYLA_APP_ID = "CJIOSP-id"
+AYLA_APP_SECRET = "CJIOSP-Vb8MQL_lFiYQ7DKjN0eCFXznKZE"
+
 OEM_MODEL = "oem_model"
 PROP = "prop"
 DISPLAY_TEMP = "display_temperature"


### PR DESCRIPTION
In the PR for the Fujitsu HVAC code in home assistant (https://github.com/home-assistant/core/pull/109335) it was suggested that I put the API credentials in this repo instead of the homeassistant repo.

Feel free to reject if you are not comfortable with this.