### PR TITLE
Don't raise when reading an unsupported property

### DIFF
--- a/src/ayla_iot_unofficial/fujitsu_hvac.py
+++ b/src/ayla_iot_unofficial/fujitsu_hvac.py
@@ -353,7 +353,7 @@ class FujitsuHVAC(Device):
     @property
     def horizontal_swing(self) -> bool:
         if not self.has_capability(Capability.SWING_HORIZONTAL):
-            raise SettingNotSupportedError("Device does not support horizontal swing")
+            return False
 
         return self.property_values[HORIZ_SWING_PARAM_MAP[self.model]] == SWING_VAL_MAP[self.model][True]
 
@@ -373,7 +373,7 @@ class FujitsuHVAC(Device):
     @property
     def vertical_swing(self) -> bool:
         if not self.has_capability(Capability.SWING_VERTICAL):
-            raise SettingNotSupportedError("Device does not support vertical swing")
+            return False
 
         return self.property_values[VERT_SWING_PARAM_MAP[self.model]] == SWING_VAL_MAP[self.model][True]
 


### PR DESCRIPTION
Instead of raising an exception while trying to read a property that isn't supported by the device, return a sensible value.

This should fix https://github.com/home-assistant/core/issues/124947