### PR TITLE
Ensure we send half degree C increments to the API

### DIFF
--- a/src/ayla_iot_unofficial/fujitsu_hvac.py
+++ b/src/ayla_iot_unofficial/fujitsu_hvac.py
@@ -335,7 +335,9 @@ class FujitsuHVAC(Device):
 
     @set_temp.setter
     def set_temp(self, val: float):
-        self.set_property_value(ADJUST_TEMPERATURE, int(val * 10.0))
+        # Sometimes F to C conversion doesn't land on a half degree multiple
+        # so round to the nearest 0.5C
+        self.set_property_value(ADJUST_TEMPERATURE, int((round(val*2.0) / 2.0) * 10.0))
 
     async def async_set_set_temp(self, val: float):
         await self.async_set_property_value(ADJUST_TEMPERATURE, int(val * 10.0))

--- a/src/ayla_iot_unofficial/fujitsu_hvac.py
+++ b/src/ayla_iot_unofficial/fujitsu_hvac.py
@@ -340,7 +340,7 @@ class FujitsuHVAC(Device):
         self.set_property_value(ADJUST_TEMPERATURE, int((round(val*2.0) / 2.0) * 10.0))
 
     async def async_set_set_temp(self, val: float):
-        await self.async_set_property_value(ADJUST_TEMPERATURE, int(val * 10.0))
+        await self.async_set_property_value(ADJUST_TEMPERATURE, int((round(val*2.0) / 2.0) * 10.0))
 
     @property
     def supported_swing_modes(self) -> list[SwingMode]:


### PR DESCRIPTION
The API only want half degree C increments for the value of the set temperature. Sometime when there is a conversion from F to C we land on non half degree aligned values, this makes sure that we re-align those values before sending them out.