### PR TITLE
add support for token signin

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ pip install ayla-iot-unofficial
 Requires typical http interaction and datatype packages like requests, aiohttp, ujson
 
 ## User Requirements
-Reqiures a username and password (typically a smart device's app login credentials)
+Reqiures either a username and password (typically a smart device's app login credentials) or a token (retrieved from device manufacturer's login flow)
 Requires an app_id and app_secret (granted by Ayla to the smart device's app for operation/integration)
 
 The app_id and app_secret may need to be obtained from proxy traffic or other method.
@@ -81,6 +81,17 @@ softener = devices[1]
 
 softener.capacity_remaining_gallons
 softener.set_vacation_mode()
+```
+
+### Login via token
+
+Some devices like the De'Longhi DDSX Dehumidifier are accessed by logging into the manufacturer's app which then generates a token for logging into Ayla Networks.
+
+```python
+TOKEN = 'st2...'
+
+ayla_api = new_ayla_api(None, None, APP_ID, APP_SECRET, token=TOKEN)
+ayla_api.sign_in()
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -85,12 +85,12 @@ softener.set_vacation_mode()
 
 ### Login via token
 
-Some devices like the De'Longhi DDSX Dehumidifier are accessed by logging into the manufacturer's app which then generates a token for logging into Ayla Networks.
+Some devices like the De'Longhi DDSX Dehumidifier are accessed by logging into the manufacturer's app which then generates an SSO token for logging into Ayla Networks.
 
 ```python
-TOKEN = 'st2...'
+SSO_TOKEN = 'st2...'
 
-ayla_api = new_ayla_api(None, None, APP_ID, APP_SECRET, token=TOKEN)
+ayla_api = new_ayla_api_sso(SSO_TOKEN, APP_ID, APP_SECRET)
 ayla_api.sign_in()
 ```
 


### PR DESCRIPTION
I'm looking to add Home Assistant support to my dehumidifier and reverse engineering the app shows it uses Ayla Networks but in the app you log into De'Longhi which generates a token and calls this token_sign_in endpoint I've added.

I tried to make the changes backwards-compatible. Tested these changes using the Europe URL and both sync and async token signin work. I'm planning to open a PR later to add constants for the Dehumidifier once I've figured them all out.